### PR TITLE
Add a release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,43 @@
+name: Latest Release
+
+# The release event will trigger a workflow run. This is different to
+# the MATLAB latest release workflow because we want to create
+# releases manually.
+on:
+  release:
+    types: [published]
+
+jobs:
+  # This job will build the BankfullMapper toolbox and save it as an
+  # artifact.
+  package:
+    # Check that the repository is the TopoToolbox one to avoid
+    # running this workflow on forks
+    if: github.repository == 'TopoToolbox/BankfullMapper'
+    name: Package toolbox
+    # Since BankfullMapper is a pure MATLAB toolbox, it does not need
+    # to be compiled for different platforms. We run on ubuntu just
+    # for convenience, but it should work on other platforms as well.
+    runs-on: ubuntu-latest
+    # Ensure that the job has write permissions to the repository so
+    # it can upload assets.
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Set up MATLAB
+        uses: matlab-actions/setup-matlab@v2
+        with:
+          cache: true
+      - name: Build package
+        uses: matlab-actions/run-build@v2
+        with:
+          tasks: package
+      - name: Upload toolbox assets to release
+        run: gh release upload --repo $GITHUB_REPOSITORY $TAG release/*
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}

--- a/tests/BankfullMapper_test.m
+++ b/tests/BankfullMapper_test.m
@@ -1,4 +1,4 @@
-classdef BankFullMapper_test < matlab.unittest.TestCase
+classdef BankfullMapper_test < matlab.unittest.TestCase
 
     methods (TestClassSetup)
         % Shared setup for the entire test class


### PR DESCRIPTION
To make a new release:

1. Click on "Create new release" under the "Releases" section on https://github.com/TopoToolbox/BankfullMapper.
2. Create a new tag under "Choose a tag" with the new version number (e.g. v1.0.0) and choose "main" as the target branch.
3. GitHub can generate release notes from the recent PRs, and you can supplement these with release notes in the text book.
4. Upon clicking "Publish release," the release will be available under the Releases section on the repository page, and the workflow will run.
5. In a few minutes, the packaged BankfullMapper.mltbx file will be available from the release page.

The workflow is copied largely from the TopoToolbox 3 release workflow. Because BankfullMapper is pure MATLAB, it does not need to be compiled for each operating system, and we only run it the workflow Linux. We also trigger the workflow manually rather than automatically. If a more complex build process is required in the future (such as needing platform-specific toolboxes or automatically created releases), the TopoToolbox 3 and pytopotoolbox release workflows can be used as a reference.

This PR also fixes the name of the test class to match the file so that the test runs without warnings.